### PR TITLE
Remove assumptions on result of directory operations

### DIFF
--- a/src/mstore.erl
+++ b/src/mstore.erl
@@ -136,7 +136,7 @@ new(FileSize, DataSize, Dir) ->
         {ok, F, IS,  Metrics} ->
             {ok, #mstore{size=F, dir=Dir, metrics=Metrics, data_size=IS}};
         _ ->
-            ok = file:make_dir(Dir),
+            file:make_dir(Dir),
             MStore = #mstore{size=FileSize, dir=Dir,
                              data_size=DataSize},
             ok = file:write_file(IdxFile, index_header(MStore)),
@@ -183,7 +183,7 @@ delete(MStore = #mstore{dir=Dir}) ->
     {ok, Files} = file:list_dir(Dir),
     Files1 = [[Dir, $/ | File] || File <- Files],
     [file:delete(F) || F <- Files1],
-    ok = file:del_dir(Dir).
+    file:del_dir(Dir).
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
I made a mistake in my previous patch by adding these matches to the result of the directory operations, as they do not hold.  For instance, if a directory already exists, constructing an mstore will fail.
